### PR TITLE
Update boot_order.py

### DIFF
--- a/Scripts/boot_order/boot_order.py
+++ b/Scripts/boot_order/boot_order.py
@@ -33,7 +33,9 @@ if (__name__ == '__main__'):
         exit(1)
 
     tenancy_id = os.environ.get('OCI_TENANCY')
-    config = oci.config.from_file()
+    env_config_file = os.environ.get('OCI_CONFIG_FILE')
+    env_config_section = os.environ.get('OCI_CONFIG_PROFILE')
+    config = oci.config.from_file(env_config_file, env_config_section)
     cloud_bridge_client = oci.cloud_bridge.InventoryClient(config)
 
     asset = cloud_bridge_client.get_asset(asset_id=source_asset_id).data


### PR DESCRIPTION
Script has bug that if will always only run against Home Region in cloud shell. 

Fix for when running not in the home region. 
Use the OCI_CONFIG_PROFILE environment variable to detect the region cloud shell is running in and will target that region.