### PR TITLE
Fix platform_config JSON serialization in os_update_instance script

### DIFF
--- a/Scripts/os_update_instance/update_OS_instance.py
+++ b/Scripts/os_update_instance/update_OS_instance.py
@@ -208,7 +208,7 @@ def get_instance_info(compute_client, instance_id):
             'ipxe_script' : get_instance_response.data.ipxe_script,
             'launch_options':object_to_dict(get_instance_response.data.launch_options),
             'metadata' :get_instance_response.data.metadata,
-            'platform_config':get_instance_response.data.platform_config,
+            'platform_config':oci.util.to_dict(get_instance_response.data.platform_config),
             'preemptible_instance_config':get_instance_response.data.preemptible_instance_config,
             #This property is causing launch instance failure in some cases. 
             #'source_details':object_to_dict(get_instance_response.data.source_details),


### PR DESCRIPTION
## Summary
Fixes `TypeError: Object of type AmdVmPlatformConfig is not JSON serializable` when capturing instance details by converting `platform_config` from an OCI SDK model object to a plain dict via `oci.util.to_dict()`.

## Testing
- `python -m py_compile Scripts/os_update_instance/update_OS_instance.py`
- Local repro/proof: JSON serialization fails with the raw `platform_config` object and succeeds with `oci.util.to_dict(platform_config)`.

## References
- oracle-quickstart/oci-cloud-migrations#20
- OCICM-18908
- OCMSD-18876